### PR TITLE
Pull and build containers in PDC_TMP

### DIFF
--- a/analyses/01_ebp-assembly-workflow/run_nextflow.sh
+++ b/analyses/01_ebp-assembly-workflow/run_nextflow.sh
@@ -64,6 +64,8 @@ if [ "$cluster" == "rackham" ]; then
     run_nextflow uppmax /proj/snic2021-6-194
 elif [ "$cluster" == "dardel" ]; then
     module load PDC apptainer
+    export APPTAINER_CACHEDIR=$PDC_TMP
+    export SINGULARITY_CACHEDIR=$PDC_TMP
     run_nextflow dardel /cfs/klemming/projects/snic/snic2021-6-194
 elif [ "$cluster" == "nac" ]; then
     module load Singularity

--- a/analyses/01_ebp-assembly-workflow/run_nextflow.sh
+++ b/analyses/01_ebp-assembly-workflow/run_nextflow.sh
@@ -64,8 +64,8 @@ if [ "$cluster" == "rackham" ]; then
     run_nextflow uppmax /proj/snic2021-6-194
 elif [ "$cluster" == "dardel" ]; then
     module load PDC apptainer
-    export APPTAINER_CACHEDIR=$PDC_TMP
-    export SINGULARITY_CACHEDIR=$PDC_TMP
+    export APPTAINER_CACHEDIR=$PDC_TMP/apptainer/cache
+    export SINGULARITY_CACHEDIR=$PDC_TMP/singularity/cache
     run_nextflow dardel /cfs/klemming/projects/snic/snic2021-6-194
 elif [ "$cluster" == "nac" ]; then
     module load Singularity

--- a/analyses/02_blobtoolkit/run_nextflow.sh
+++ b/analyses/02_blobtoolkit/run_nextflow.sh
@@ -64,6 +64,8 @@ if [ "$cluster" == "rackham" ]; then
     run_nextflow uppmax /proj/snic2021-6-194
 elif [ "$cluster" == "dardel" ]; then
     module load PDC apptainer
+    export APPTAINER_CACHEDIR=$PDC_TMP/apptainer/cache
+    export SINGULARITY_CACHEDIR=$PDC_TMP/singularity/cache
     run_nextflow dardel /cfs/klemming/projects/snic/snic2021-6-194
 elif [ "$cluster" == "nac" ]; then
     module load Singularity


### PR DESCRIPTION
Containers are usually built in $HOME which has a small quota, and can result in pipelines failing.

This changes where the containers are pulled and built ( when converting from docker images ) to PDC_TMP which is private to the user, has no quota limit, and only remains there for 30 days.

The final container images are still copied to the `NXF_SINGULARITY_CACHEDIR` after they've been built so they're available to everyone.