### PR TITLE
Add unset and set check for unset variables on nac

### DIFF
--- a/analyses/01_ebp-assembly-workflow/run_nextflow.sh
+++ b/analyses/01_ebp-assembly-workflow/run_nextflow.sh
@@ -26,8 +26,10 @@ function run_nextflow {
     export NXF_SINGULARITY_CACHEDIR="${STORAGEALLOC}/nobackup/ebp-singularity-cache"
 
     # Activate shared Nextflow environment
+    set +u
     eval "$(conda shell.bash hook)"
     conda activate "${STORAGEALLOC}/conda/nextflow-env"
+    set -u
 
     # Clean results folder if last run resulted in error
     if [ "$( nextflow log | awk -F $'\t' '{ last=$4 } END { print last }' )" == "ERR" ]; then

--- a/analyses/02_blobtoolkit/run_nextflow.sh
+++ b/analyses/02_blobtoolkit/run_nextflow.sh
@@ -26,8 +26,10 @@ function run_nextflow {
     export NXF_SINGULARITY_CACHEDIR="${STORAGEALLOC}/nobackup/ebp-singularity-cache"
 
     # Activate shared Nextflow environment
+    set +u
     eval "$(conda shell.bash hook)"
     conda activate "${STORAGEALLOC}/conda/nextflow-env"
+    set -u
 
     # Clean results folder if last run resulted in error
     if [ "$( nextflow log | awk -F $'\t' '{ last=$4 } END { print last }' )" == "ERR" ]; then


### PR DESCRIPTION
When activating the conda environment on nac, the script errors because `JAVA_HOME` is unset. 
Adding `set +u` and `set -u` around the environment activation prevents errors.