### PR TITLE
Add git status to nextflow launch scripts

### DIFF
--- a/analyses/01_ebp-assembly-workflow/run_nextflow.sh
+++ b/analyses/01_ebp-assembly-workflow/run_nextflow.sh
@@ -73,4 +73,5 @@ else
     exit 1
 fi
 
-
+# Print git status to remind users to checkin untracked/updated files
+git status

--- a/analyses/02_blobtoolkit/run_nextflow.sh
+++ b/analyses/02_blobtoolkit/run_nextflow.sh
@@ -73,4 +73,5 @@ else
     exit 1
 fi
 
-
+# Print git status to remind users to checkin untracked/updated files
+git status


### PR DESCRIPTION
Add a `git status` to the end of run scripts to remind analysts if they've got untracked parameter or config changes which should be pushed to the repository.