### PR TITLE
Transfer HPC profiles to assembly template

### DIFF
--- a/analyses/01_ebp-assembly-workflow/nextflow.config
+++ b/analyses/01_ebp-assembly-workflow/nextflow.config
@@ -1,6 +1,32 @@
+// Include NBIS profiles
+includeConfig '../../envs/nextflow/nbis_profiles.config'
+profiles {
+    // Override nac profile for EBP processes
+    nac {
+        includeConfig '../../envs/nextflow/nac.config'
+        params {
+            // NAC does not have enough memory to have the db in ram. (Slows FCSGX down a lot.)
+            fcs.ramdisk_path = ''
+        }
+        process {
+            // Increase resourceLimits to use highest memory nodes on NAC
+            withName: 'FCSGX_RUNGX' {
+                cpus       = 16
+                memory     = 370.GB
+                time       = 30.d
+                resourceLimits = [
+                    cpus: 16,
+                    memory: 370.GB,
+                    time: 30.d
+                ]
+            }
+        }
+    }
+}
+
 // Add custom module configuration here
 
-// E.g Use high memory node for HIFIASM
+// E.g Use Rackham high memory node for HIFIASM
 // process {
 //     withName: 'HIFIASM' {
 //         cpus   = 20

--- a/analyses/02_blobtoolkit/nextflow.config
+++ b/analyses/02_blobtoolkit/nextflow.config
@@ -1,3 +1,6 @@
+// Include NBIS profiles
+includeConfig '../../envs/nextflow/nbis_profiles.config'
+
 // Add custom module configuration here
 
 // E.g Use high memory node for HIFIASM

--- a/envs/nextflow/nac.config
+++ b/envs/nextflow/nac.config
@@ -1,0 +1,28 @@
+process {
+    // resource limits are based on most nodes of the abc partition on nac:
+    // 15    CfgTRES=cpu=16,mem=120G,billing=16
+    //  3    CfgTRES=cpu=36,mem=375G,billing=36
+    // MaxTime=30-00:00:00
+    // Processes that require more resources need to explicitly overwrite it
+    resourceLimits = [
+        cpus:   16,
+        memory: 120.GB, // Limit to 120 so most jobs go to 120G nodes rather than waiting for 3 375G nodes
+        time:   30.d,
+    ]
+    withName: 'FCSGX_RUNGX' {
+        cpus       = 16
+        memory     = 370.GB
+        time       = 30.d
+        resourceLimits = [
+            cpus: 16,
+            memory: 370.GB,
+            time: 30.d
+        ]
+    }
+    executor     = 'slurm'
+    scratch      = '/scratch'
+}
+
+singularity {
+    enabled      = true
+}

--- a/envs/nextflow/nac.config
+++ b/envs/nextflow/nac.config
@@ -9,16 +9,6 @@ process {
         memory: 120.GB, // Limit to 120 so most jobs go to 120G nodes rather than waiting for 3 375G nodes
         time:   30.d,
     ]
-    withName: 'FCSGX_RUNGX' {
-        cpus       = 16
-        memory     = 370.GB
-        time       = 30.d
-        resourceLimits = [
-            cpus: 16,
-            memory: 370.GB,
-            time: 30.d
-        ]
-    }
     executor     = 'slurm'
     scratch      = '/scratch'
 }

--- a/envs/nextflow/nbis_profiles.config
+++ b/envs/nextflow/nbis_profiles.config
@@ -15,25 +15,5 @@ profiles {
     // NBIS: NAC
     nac {
         includeConfig 'nac.config'
-
-        process {
-            // resource limits are based on most nodes of the abc partition on nac:
-            // 15    CfgTRES=cpu=16,mem=120G,billing=16
-            //  3    CfgTRES=cpu=36,mem=375G,billing=36
-            // MaxTime=30-00:00:00
-            // Processes that require more resources need to explicitly overwrite it
-            resourceLimits = [
-                cpus:   16,
-                memory: 120.GB, // Limit to 120 so most job 120G nodes rather than waiting for 3 375G nodes
-                time:   30.d,
-            ]
-            executor     = 'slurm'
-            scratch      = '/scratch'
-        }
-
-        singularity {
-            enabled      = true
-        }
     }
-
 }

--- a/envs/nextflow/nbis_profiles.config
+++ b/envs/nextflow/nbis_profiles.config
@@ -4,7 +4,6 @@ profiles {
     // UPPMAX: Rackham
     uppmax {
         includeConfig 'https://raw.githubusercontent.com/nf-core/configs/refs/heads/master/conf/uppmax.config'
-
     }
 
     // PDC-KTH: Dardel

--- a/envs/nextflow/nbis_profiles.config
+++ b/envs/nextflow/nbis_profiles.config
@@ -1,7 +1,7 @@
 // NBIS profiles 
 
 profiles {
-    // Uppmax: Rackham
+    // UPPMAX: Rackham
     uppmax {
         includeConfig 'https://raw.githubusercontent.com/nf-core/configs/refs/heads/master/conf/uppmax.config'
 

--- a/envs/nextflow/nbis_profiles.config
+++ b/envs/nextflow/nbis_profiles.config
@@ -1,0 +1,39 @@
+// NBIS profiles 
+
+profiles {
+    // Uppmax: Rackham
+    uppmax {
+        includeConfig 'https://raw.githubusercontent.com/nf-core/configs/refs/heads/master/conf/uppmax.config'
+
+    }
+
+    // PDC-KTH: Dardel
+    dardel {
+        includeConfig 'https://raw.githubusercontent.com/nf-core/configs/refs/heads/master/conf/pdc_kth.config'
+    }
+
+    // NBIS: NAC
+    nac {
+        includeConfig 'nac.config'
+
+        process {
+            // resource limits are based on most nodes of the abc partition on nac:
+            // 15    CfgTRES=cpu=16,mem=120G,billing=16
+            //  3    CfgTRES=cpu=36,mem=375G,billing=36
+            // MaxTime=30-00:00:00
+            // Processes that require more resources need to explicitly overwrite it
+            resourceLimits = [
+                cpus:   16,
+                memory: 120.GB, // Limit to 120 so most job 120G nodes rather than waiting for 3 375G nodes
+                time:   30.d,
+            ]
+            executor     = 'slurm'
+            scratch      = '/scratch'
+        }
+
+        singularity {
+            enabled      = true
+        }
+    }
+
+}


### PR DESCRIPTION
The aim is to move the HPC executor profiles to our assembly template.

By including a config that's sharable between analyses we don't need to redefine the configuration every time. For example, we can now include a single line in the nextflow.config and can then use other Nextflow workflows like Blobtoolkit with profiles like `dardel`.