### PR TITLE
Smoothen processing

### DIFF
--- a/analyses/01_ebp-assembly-workflow/workflow_parameters.yml
+++ b/analyses/01_ebp-assembly-workflow/workflow_parameters.yml
@@ -1,12 +1,9 @@
 project: 'naiss2023-5-307'
 input: 'assembly_parameters.yml'
-# fastk: # Optional
-#   kmer_size: 31 # default 31
-# genescopefk: # Optional
-#   kmer_size: 31 # default 31
+steps: 'inspect,preprocess,assemble,screen,purge'
 # hifiasm: # Optional, default = no extra options: Key (e.g. 'opts01') is used in assembly build name (e.g., 'hifiasm-raw-opts01').
 #   opts01: "--opts A"
 #   opts02: "--opts B"
-# busco:
+busco:
 #   lineages: 'auto' # comma separated string of lineages or auto. default: retrieved from GOAT
-#   lineages_db_path: '/sw/data/BUSCO_data/latest/rackham/v5_lineage_sets/lineages'
+  lineages_db_path: '/sw/data/BUSCO_data/latest/rackham/v5_lineage_sets'

--- a/analyses/01_ebp-assembly-workflow/workflow_parameters.yml
+++ b/analyses/01_ebp-assembly-workflow/workflow_parameters.yml
@@ -1,6 +1,6 @@
 project: 'naiss2023-5-307'
 input: 'assembly_parameters.yml'
-steps: 'inspect,preprocess,assemble,screen,purge'
+steps: 'inspect,preprocess,assemble,screen,purge,scaffold'
 # hifiasm: # Optional, default = no extra options: Key (e.g. 'opts01') is used in assembly build name (e.g., 'hifiasm-raw-opts01').
 #   opts01: "--opts A"
 #   opts02: "--opts B"


### PR DESCRIPTION
- Fixes busco lineage database path
- Makes default steps up to purge since curationpretext is now used for downstream.