### PR TITLE
Add pixi task to check slurm jobs

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -87,6 +87,8 @@ assembly = { cmd = "run_nextflow.sh", cwd = "analyses/01_ebp-assembly-workflow/"
 nextflow = "cd $INIT_CWD && ./run_nextflow.sh"
 # Clean up
 clean-work = "cd $INIT_CWD && nextflow clean -f -before $(nextflow log -q | tail -n 1) && find work/ -type d -empty -delete"
+# Check slurm jobs since start time (default: last 3 days)
+check-slurm = { cmd = "sacct -X --user=$USER -S {{ start_time }} --format=JobID,JobName,State,ExitCode,Start,End -n -p", args = [ { arg = "start_time", default = "now-3days" } ] }
 
 [feature.sanger-curation-utils.dependencies]
 python = ">=3.10"


### PR DESCRIPTION
Resolves #37. 

Adds a Pixi task to check slurm jobs in the last 3 days. 

`-X` suppresses `.batch` and `.extern` output
`-n` suppresses the header
`-p` gives parse-able output, but importantly prints the whole job name.
`-S` is the start time and one can do `now-3days` to provide a relative time.