### PR TITLE
Add pixi tasks for BTK

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -76,7 +76,7 @@ args = [
     { arg = "blobdir" }
 ]
 cmd = """
-singularity exec \
+cd $INIT_CWD && singularity exec \
     -B $PWD \
     -B /scratch \
     $NXF_SINGULARITY_CACHEDIR/docker.io-genomehubs-blobtoolkit-4.4.6.img \


### PR DESCRIPTION
- On Mac, uses the BTK viewer via docker to view a blob locally
- On Linux, sets up a remote session to the BTK viewer. User needs to then enable port forwarding themselves. 